### PR TITLE
Add POST endpoint tests for happy / sad paths

### DIFF
--- a/app.js
+++ b/app.js
@@ -21,8 +21,6 @@ const corsOptions = {
 
 app.use(express.json())
 
-app.get('/', (req, res) => res.send('Hello Girl!'))
-
 app.get('/api/v1/projects', (request, response) => {
   database('projects').select()
     .then((projects) => {

--- a/app.test.js
+++ b/app.test.js
@@ -7,6 +7,7 @@ const app = require('./app');
 const projects = require('./projects');
 const palettes = require('./palettes');
 
+
 describe('/api/v1', () => {
 
   beforeEach(async () => {
@@ -15,7 +16,7 @@ describe('/api/v1', () => {
 
   describe('GET /projects', () => {
 
-    it('should return all projects in the database', async () => {
+    it('should return all `projects` in the database', async () => {
       const expectedProjectsLength = projects.length;
       const response = await request(app).get('/api/v1/projects');
       const result = response.body;
@@ -24,57 +25,196 @@ describe('/api/v1', () => {
 
   })
 
-  describe('GET/ projects/:id sad path', () => {
-    it('should return a single project', async () => {
-      const id = 'Q'
-      const res = await request(app).get(`/api/v1/projects/${id}`)
-      expect(res.status).toBe(500)
-      })
+  describe('GET/ projects/:id', () => {
+
+    it('should return a specific `project` from the database', async () => {
+      const expectedProject = await database('projects').first();
+      const id = expectedProject.id;
+
+      const response = await request(app).get(`/api/v1/projects/${id}`);
+
+      expect(response.body[0].id).toEqual(expectedProject.id);
+      expect(response.body[0].title).toEqual(expectedProject.title);
+    })
+
+    it('should return a 404 status code and error message if `project` is not found', async () => {
+      const fakeId = 1;
+
+      const response = await request(app).get(`/api/v1/projects/${fakeId}`);
+
+      expect(response.status).toBe(404);
+      expect(response.body.error).toEqual(`Could not find a project with id ${fakeId}`);
+    })
+
+    it('should return a 500 status code and an error object', async () => {
+      const id = 'Q';
+
+      const response = await request(app).get(`/api/v1/projects/${id}`);
+
+      expect(response.status).toBe(500);
+      expect(response.body.error).toEqual({"code": "22P02", "file": "numutils.c", "length": 90, "line": "62", "name": "error", "routine": "pg_atoi", "severity": "ERROR"});
+    })
+
   })
   
   describe('GET /palettes', () => {
-    it('should return all the palettes in the DB', async ()=> {
-      const expectedpalettes = palettes.length
-      const res = await request(app).get('/api/v1/palettes')
-      const result = res.body
-      expect(result.length).toEqual(expectedpalettes)
+
+    it('should return all `palettes` in the database', async ()=> {
+      const expectedPalettes = palettes.length;
+
+      const response = await request(app).get('/api/v1/palettes');
+
+      expect(response.body.length).toEqual(expectedPalettes);
     })
+
   })
   
-  describe('GET/ palettes/:id', () => {
-    it('should return a single project', async () => {
-      const expectedPalette = await database('palettes').first()
-      const id = expectedPalette.id
-      const res = await request(app).get(`/api/v1/palettes/${id}`)
-      const result = res.body[0]
-      expect(result.id).toBe(expectedPalette.id)
-      })
+  describe('GET /palettes/:id', () => {
+
+    it('should return a specific `palette` from the database', async () => {
+      const expectedPalette = await database('palettes').first();
+      const id = expectedPalette.id;
+
+      const response = await request(app).get(`/api/v1/palettes/${id}`);
+
+      expect(response.body[0].id).toBe(expectedPalette.id);
+    })
+
+    it('should return a 404 status code and error message if `palette` is not found', async () => {
+      const fakeId = 1;
+
+      const response = await request(app).get(`/api/v1/palettes/${fakeId}`);
+      
+      expect(response.status).toBe(404);
+      expect(response.body.error).toEqual(`Could not find a palette with id ${fakeId}`);
+    })
+
+    it('should return a 500 status code and an error object', async () => {
+      const id = 'Q';
+
+      const response = await request(app).get(`/api/v1/palettes/${id}`);
+
+      expect(response.status).toBe(500);
+      expect(response.body.error).toEqual({"code": "22P02", "file": "numutils.c", "length": 90, "line": "62", "name": "error", "routine": "pg_atoi", "severity": "ERROR"});
+    })
+
   })
-  
-  describe('GET/ palettes/:id sad path', () => {
-    it('should return a single project', async () => {
-      const id = 'Q'
-      const res = await request(app).get(`/api/v1/palettes/${id}`)
-      expect(res.status).toBe(500)
-      })
+
+  describe('POST /projects', () => {
+
+    it('should add a `project` to the database', async () => {
+      const newProject = { title: 'Test Project' };
+
+      const response = await request(app).post('/api/v1/projects').send(newProject);
+      const project = await database('projects').where('id', response.body.id).select();
+
+      expect(project[0].title).toEqual(newProject.title);
+    })
+
+    it('should return a 422 status code and an error message', async () => {
+      const newProject = { tijle: 'Test Project' };
+
+      const response = await request(app).post('/api/v1/projects').send(newProject);
+
+      expect(response.status).toBe(422);
+      expect(response.body.error).toEqual("Expected format: { title: <String> }. You're missing a \"title\" property.");
+    })
+
+  })
+
+  describe('POST /palettes', () => {
+
+    it('should add a `palette` to the database', async () => {
+      const newPalette = { 
+        name: 'Test palette', 
+        color1: 'red', 
+        color2: 'green', 
+        color3: 'orange', 
+        color4: 'purple', 
+        color5: 'white'
+      };
+
+      const response = await request(app).post('/api/v1/palettes').send(newPalette);
+      const palette = await database('palettes').where('id', response.body.id).select();
+
+      expect(palette[0].name).toEqual(newPalette.name);
+    })
+
+    it('should return a 422 status code and an error message', async () => {
+      const newPalette = { 
+        name: 'Test palette', 
+        color1: 'red'
+      };
+
+      const response = await request(app).post('/api/v1/palettes').send(newPalette);
+      let errorMessage = "Expected format: { name: <String>, color1: <String>, color2: <String>, color3: <String>, color4: <String>, color5: <String>}. You're missing a \"color2\" property.";
+      
+      expect(response.status).toBe(422);
+      expect(response.body.error).toEqual(errorMessage);
+    })
+
   })
 
   describe('DELETE/ projects/:id', () => {
-    it('should delete a project by its id', async () => {
-      const expectedProject = await database('projects').first()
-      const id = expectedProject.id
-      const res = await request(app).delete(`/api/v1/projects/${id}`)
-      expect(res.status).toBe(204)
+
+    it('should delete a `project` by its id', async () => {
+      const expectedProject = await database('projects').first();
+      const id = expectedProject.id;
+
+      const response = await request(app).delete(`/api/v1/projects/${id}`);
+
+      expect(response.status).toBe(204);
     })
+
+    it('should return a 404 status code and an error message', async () => {
+      const fakeId = 1;
+
+      const response = await request(app).delete(`/api/v1/projects/${fakeId}`);
+
+      expect(response.status).toBe(404);
+      expect(response.body.error).toEqual(`Could not find a project with id ${fakeId}`);
+    })
+
+    it('should return a 500 status code and an error object', async () => {
+      const id = 'Q';
+
+      const response = await request(app).delete(`/api/v1/projects/${id}`);
+
+      expect(response.status).toBe(500);
+      expect(response.body.error).toEqual({"code": "22P02", "file": "numutils.c", "length": 90, "line": "62", "name": "error", "routine": "pg_atoi", "severity": "ERROR"});
+    })
+
   })
 
   describe('DELETE/ palettes/:id', () => {
-    it('should delete a palette by its id', async () => {
-      const expectedPalette = await database('palettes').first()
-      const id = expectedPalette.id
-      const res = await request(app).delete(`/api/v1/palettes/${id}`)
-      expect(res.status).toBe(204)
+
+    it('should delete a `palette` by its id', async () => {
+      const expectedPalette = await database('palettes').first();
+      const id = expectedPalette.id;
+
+      const response = await request(app).delete(`/api/v1/palettes/${id}`);
+
+      expect(response.status).toBe(204);
     })
+
+    it('should return a 404 status code and an error message', async () => {
+      const fakeId = 1;
+
+      const response = await request(app).delete(`/api/v1/palettes/${fakeId}`);
+
+      expect(response.status).toBe(404);
+      expect(response.body.error).toEqual(`Could not find a palette with id ${fakeId}`);
+    })
+
+    it('should return a 500 status code and an error object', async () => {
+      const id = 'Q';
+
+      const response = await request(app).delete(`/api/v1/palettes/${id}`);
+
+      expect(response.status).toBe(500);
+      expect(response.body.error).toEqual({"code": "22P02", "file": "numutils.c", "length": 90, "line": "62", "name": "error", "routine": "pg_atoi", "severity": "ERROR"});
+    })
+
   })
 
 })

--- a/db/seeds/test/palettes.js
+++ b/db/seeds/test/palettes.js
@@ -13,7 +13,6 @@ exports.seed = function(knex, Promise) {
             { name: 'House Decor', color1: 'red', color2: 'green', color3: 'orange', color4: 'purple', color5: 'white', project_id: project[0] }
           ])
         })
-        .then(() => console.log('Seeding complete!'))
         .catch(error => console.log(`Error seeding data: ${error}`))
       ])
     })

--- a/package.json
+++ b/package.json
@@ -17,6 +17,12 @@
   "scripts": {
     "test": "jest --watchAll"
   },
+  "jest": {
+    "collectCoverageFrom": [
+      "**/*.{js}", 
+      "!db/seeds/test/palettes.js"
+    ]
+  },
   "keywords": [],
   "author": "",
   "license": "ISC"


### PR DESCRIPTION
### Changes Made:
- Refactored entire testing file
- Added `happy/sad` path testing for `POST` endpoints
- Added `sad` path testing for `DELETE` endpoints

### Relevant Screenshots:
N/A

#### Message for reviewer:

#### Testing complete?
- [x] Yes
- [ ] Not yet

#### Final checklist:
- [x] My code has no unused/commented out code
- [x] I have reviewed my code
- [ ] I have commented my code, particularly in hard-to-understand areas